### PR TITLE
refactor analysis slot in initial-boundary-value-problem-schema

### DIFF
--- a/packages/initial-boundary-value-problem-schema/classes/ImportElement/_this.yaml
+++ b/packages/initial-boundary-value-problem-schema/classes/ImportElement/_this.yaml
@@ -1,0 +1,3 @@
+is_a: Element
+description: Represents an element imported from a package
+slots: ((slots.yaml))

--- a/packages/initial-boundary-value-problem-schema/classes/ImportElement/slots.yaml
+++ b/packages/initial-boundary-value-problem-schema/classes/ImportElement/slots.yaml
@@ -1,0 +1,1 @@
+- imports

--- a/packages/initial-boundary-value-problem-schema/classes/QuantifiableElement/slots.yaml
+++ b/packages/initial-boundary-value-problem-schema/classes/QuantifiableElement/slots.yaml
@@ -1,4 +1,3 @@
 - description
 - variable
 - unit
-- imports

--- a/packages/initial-boundary-value-problem-schema/classes/_this.yaml
+++ b/packages/initial-boundary-value-problem-schema/classes/_this.yaml
@@ -1,4 +1,5 @@
 Element: ((Element/_this.yaml))
+ImportElement: ((ImportElement/_this.yaml))
 QuantifiableElement: ((QuantifiableElement/_this.yaml))
 Quantity: ((Quantity/_this.yaml))
 Parameter: ((Parameter/_this.yaml))

--- a/packages/initial-boundary-value-problem-schema/slots/analysis/_this.yaml
+++ b/packages/initial-boundary-value-problem-schema/slots/analysis/_this.yaml
@@ -1,4 +1,6 @@
 description: Ordered list of computations used for conducting a initial-boundary value problem
 multivalued: true
 inlined_as_list: true
-range: ClosedFormSolution
+any_of:
+  - range: ClosedFormSolution
+  - range: ImportElement

--- a/packages/initial-boundary-value-problem-schema/slots/description/_this.yaml
+++ b/packages/initial-boundary-value-problem-schema/slots/description/_this.yaml
@@ -1,2 +1,3 @@
 description: A fully descriptive name of a quantity
+required: true
 close_mappings: ((close_mappings.yaml))

--- a/packages/initial-boundary-value-problem-schema/slots/variable/_this.yaml
+++ b/packages/initial-boundary-value-problem-schema/slots/variable/_this.yaml
@@ -1,1 +1,2 @@
 description: Mathematical variable used to represent a computation
+required: true


### PR DESCRIPTION
- remove imports slot from QuantifiableElement class
- create ImportElement class with imports slot
- redefine analysis slot to be of either range QuantifiableElement or ImportElement
- set `required: true` for description and variable slot